### PR TITLE
took ownership of collective.dexteritytextindexer (since I'm the creator)

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -263,6 +263,10 @@ owners = garbas thet
 teams = contributors
 owners = thet rnixx
 
+[repo:collective.dexteritytextindexer]
+teams = contributors
+owners = jone phgross davisagli
+
 #
 # bellow this line are repositories that were not reviewed yet
 # ------------------------------------------------------------
@@ -372,10 +376,6 @@ teams = contributors
 owners = garbas
 
 [repo:Pillow]
-teams = contributors
-owners = garbas
-
-[repo:collective.dexteritytextindexer]
 teams = contributors
 owners = garbas
 


### PR DESCRIPTION
took ownership of collective.dexteritytextindexer (since I'm the creator) and added phgross and davisagli too (hit-by-the-bus protection)
