### PR TITLE
Added collective.addthis fork under collective.github.com

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -678,3 +678,9 @@ owners = garbas
 [repo:example.base960theme]
 teams = contributors
 owners = garbas
+
+[repo:collective.addthis]
+fork = pingviini/collective.addthis
+teams = contributors
+owners = pingviini
+


### PR DESCRIPTION
Hi!

I forked collective.github.com to add my collective.addthis repo under collective organization. I understood this would be the correct approach to get permissions to add more repos without forking, am I right? If so, could you please pull my changes to the master.
- Jukka Ojaniemi (pingviini)
