### PR TITLE
add collective.js.jqueryui and collective.scss repository

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -697,6 +697,11 @@ owners = toutpt
 [repo:collective.js.jqueryui]
 teams = contributors
 owners = toutpt
+
+[repo:collective.scss]
+teams = contributors
+owners = toutpt
+
 #
 # below this line are repositories that were not reviewed yet
 # (i.e. garbas owns them all, when their "real" owners should


### PR DESCRIPTION
Moving collective.js.jqueryui from svn collective + scss integration into Plone.
