### PR TITLE
Add plone.portlet.viewlet

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -46,6 +46,7 @@ members =
     cstengel
     d2m
     danilofreitas
+    danjacka
     datakurre
     davidblewett
     davidemoro
@@ -464,7 +465,7 @@ teams = contributors
 owners = helmantel
 
 [repo:collective.swfobject]
-fork = toutpt/collective.swfobject
+fork=  toutpt/collective.swfobject
 teams = contributors
 owners = toutpt
 
@@ -1414,3 +1415,7 @@ owners = fschulze mjpieters davisagli jensens
 teams = contributors
 owners = naro
 
+[repo:plone.portlet.viewlet]
+fork = danjacka/plone.portlet.viewlet
+teams = contributors
+owners = danjacka lrowe


### PR DESCRIPTION
Migrate plone.portlet.viewlet repository from Subversion.

I've followed instructions from garbas:

"use github's import from svn functionality to import it to you
personal gihub account. then fork it to github.com/collective as
described [on] http://collective.github.com/"
