### PR TITLE
Ready for Products.remember migration

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -102,6 +102,7 @@ members =
     jonstahl
     jpgimenez
     kcleong
+    kenmanheimer
     keul
     kingel
     kiorky
@@ -1201,6 +1202,10 @@ owners = eea
 [repo:collective.js.highslide]
 teams = contributors
 owners = vangheem
+
+[repo:Products.remember]
+teams = contributors
+owners = kenmanheimer rpatterson
 
 #
 # below this line are repositories that were not reviewed yet


### PR DESCRIPTION
I've added myself to contributors and Products.remember to repos, and will do the migration once you all have made the arrangements.

I have one question.  I notice that some SVN repos that have been migrated have the trunk SVN directory changed, eg "trunk-MOVED-TO-GITHUB-COLLECTIVE".  I like the security of not doing any removals - do you recommend against doing that, are there drawbacks to it?  If not, I'm going to do that with Products.remember.  (I'm going to ask this question in an email to Alex Clark, as well, but figure it can't hurt to convey it here.)
