### PR TITLE
I would like to add a repo 'collective.getusers'

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1477,8 +1477,3 @@ owners = ericof hvelarde lepri cleberjsantos
 [repo:collective.portlet.search]
 teams = contributors
 owners = ericof hvelarde lepri cleberjsantos
-
-[repo:collective.getusers]
-fork = bsuttor/collective.getusers
-teams = contributors
-owners = bsuttor


### PR DESCRIPTION
This repo is curently there : https://github.com/bsuttor/collective.getusers, but i would like to move it into the collective.
