### PR TITLE
add cewing to contributors group

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -39,6 +39,7 @@ members =
     campbellbasset
     chaoflow
     chervol
+    cewing
     claytron
     cleberjsantos
     cleder


### PR DESCRIPTION
Could you please pull this fork so that I can have contributor access to the github collective?  Thanks very much!
