### PR TITLE
Add collective.upgrade repo

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1548,3 +1548,7 @@ owners = iElectric pysailor zupo
 [repo:collective.recipe.jenkinsjob]
 teams = contributors
 owners = iElectric tisto
+
+[repo:collective.upgrade]
+teams = contributors
+owners = rpatterson


### PR DESCRIPTION
This is my first repo add to the collective, so I'd love a sanity check.  I started this repo in my own github space:

https://github.com/rpatterson/collective.upgrade

Does that mean I need to do anything special to move it into the collective?  Or can I just do this change and then push to it when it's created?
