### PR TITLE
Add a new repo to collective

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1552,3 +1552,7 @@ owners = iElectric tisto
 [repo:collective.upgrade]
 teams = contributors
 owners = rpatterson
+
+[repo:collective.person]
+teams = contributors
+owners = ericof hvelarde Quimera


### PR DESCRIPTION
collective.person will be moved from github.com/simplesconsultoria to github.com/collective
