### PR TITLE
New repo for collective.myrecentcontent

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1581,3 +1581,7 @@ owners = jensens
 [repo:plone.app.event-ploneintegration]
 teams = contributors
 owners = thet
+
+[repo:collective.myrecentcontent]
+teams = contributors
+owners = rpatterson


### PR DESCRIPTION
Add a new repo for a p.a.toolbar menu of links to the current author's recently changed content.
