### PR TITLE
Fix zopeskel.unis owners

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -278,7 +278,7 @@ owners = garbas
 
 [repo:zopeskel.unis]
 teams = contributors
-owners = garbas
+owners = encolpe
 
 [repo:TracCIANotification]
 teams = contributors


### PR DESCRIPTION
Hello,

I regain ownership on zopeskel.unis repository.
Other contributors didn't ask for access in the collective.

Regards,
Encolpe
