### PR TITLE
new repos: collective.z3cform.keywordwidget

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1526,3 +1526,7 @@ owners = sjoerdve
 [repo:plonetheme.responsive1140]
 teams = contributors
 owners = toutpt
+
+[repo:collective.z3cform.keywordwidget]
+teams = contributors
+owners = petschki do3cc jcbrand pilz naro


### PR DESCRIPTION
move from svn.plone.org to github.com
