### PR TITLE
Get proper access to Products.remember

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1483,7 +1483,7 @@ owners = kroman0 chervol
 
 [repo:Products.remember]
 teams = contributors
-owners = kenmanheimer rpatterson mauritsvanrees
+owners = kenmanheimer mauritsvanrees rpatterson
 
 [repo:Products.Poi]
 teams = contributors


### PR DESCRIPTION
After I got access to Products.remember earlier today I had removed that repository, as the import needed to be done from scratch again due to missing branches and tags.  Looks like the repo has been recreated now, but I cannot push there yet.

Hopefully this simple fix (reordering the team members) fixes it. If not, then I may have triggered a silly corner case in the used scripts; if anyone can fix that manually (or advice me on the proper procedure here) then that would be cool.
