### PR TITLE
Add templer.plone.localcommands repository to collective

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -2033,3 +2033,7 @@ owners = kroman0 chervol
 [repo:collective.linkcheck]
 teams = contributors
 owners = malthe
+
+[repo:templer.plone.localcommands]
+teams = contributors
+owners = cewing


### PR DESCRIPTION
The package will support the re-integration of localcommands to the plone and archetypes templates in templer and zopeskel 3
