### PR TITLE
Add collective.table permissions

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1172,6 +1172,10 @@ fork = toutpt/collective.swfobject
 teams = contributors
 owners = toutpt
 
+[repo:collective.table]
+teams = contributors
+owners = zupo danjacka
+
 [repo:collective.teaser]
 teams = contributors
 owners = thet


### PR DESCRIPTION
zupo has migrated collective.table from github.com/zupo to the collective. Add he and I as owners.
