### PR TITLE
add repo:collective.spanishdocumentation

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1216,6 +1216,11 @@ owners = jensens agitator
 teams = contributors
 owners = davidjb
 
+[repo:collective.spanishdocumentation]
+fork = macagua/collective.spanishdocumentation
+teams = contributors
+owners = macagua
+
 [repo:collective.stats]
 teams = contributors
 owners = aclark4life fafhrd91
@@ -1399,7 +1404,7 @@ owners = datakurre
 
 [repo:cyn.in]
 teams = contributors
-owners = garbas
+owners = macagua
 
 [repo:dateable.chronos]
 teams = contributors


### PR DESCRIPTION
Please add repo collective.spanishdocumentations to the collective from macagua and set as owners to macagua in repo:cyn.in

Thanks you!!!
