### PR TITLE
Add collective.js.lightbox2 project 

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -957,7 +957,7 @@ owners = sneridagh
 teams = contributors
 owners = claytron
 
-[repo:collective.lightbox2]
+[repo:collective.js.lightbox2]
 teams = contributors
 owners = mitchellrj
 


### PR DESCRIPTION
To replace unmaintained PloneLightboxJS product. http://plone.org/products/plonelightboxjs
