### PR TITLE
removed eea packages that will be re-added later as forks from the eea organisation instead.

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1807,6 +1807,21 @@ fork = eea/eea.faceted.vocabularies
 teams = contributors
 owners = demarant alecghica avoinea
 
+[repo:eea.facetednavigation]
+fork = eea/eea.facetednavigation
+teams = contributors
+owners = demarant alecghica avoinea
+
+[repo:eea.jquery]
+fork = eea/eea.jquery
+teams = contributors
+owners = demarant alecghica avoinea
+
+[repo:eea.tags]
+fork = eea/eea.tags
+teams = contributors
+owners = demarant alecghica avoinea
+
 [repo:example.base960theme]
 teams = contributors
 owners = toutpt


### PR DESCRIPTION
removed eea packages that will be re-added later as forks from the eea organisation instead.
