### PR TITLE
change new collective.js.tree repo to collective.jstree

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1046,10 +1046,6 @@ owners = garbas
 teams = contributors
 owners = garbas
 
-[repo:collective.js.tree]
-teams = contributors
-owners = rochecompaan vincic witekdev
-
 [repo:collective.js.ui.multiselect]
 teams = contributors
 owners = elioschmutz jone maethu
@@ -1057,6 +1053,10 @@ owners = elioschmutz jone maethu
 [repo:collective.js.underscore]
 teams = contributors
 owners = href
+
+[repo:collective.jstree]
+teams = contributors
+owners = rochecompaan vincic witekdev
 
 [repo:collective.jsonify]
 teams = contributors


### PR DESCRIPTION
This is to match the original repo in the svn collective.
