### PR TITLE
Add/fork robotsuite (wraps Robot Framework test suites for zope.testrunner)

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -2409,6 +2409,11 @@ owners = giacomos
 teams = contributors
 owners = kenmanheimer mauritsvanrees rpatterson
 
+[repo:robotsuite]
+fork = datakurre/robotsuite
+teams = contributors
+owners = datakurre
+
 [repo:Products.ShibbolethPermissions]
 teams = contributors
 owners = tomgross


### PR DESCRIPTION
Because this is currently being tested in p.a.collection *), I'd feel better if this lived in collective.

*) https://github.com/plone/plone.app.collection/commit/a04c3a9e62cd2622b7743f59481bdfcf1b1b0317
