### PR TITLE
Added ramonski user and collective.uploadify repository

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -212,6 +212,7 @@ members =
     rafaelbco
     rafahela
     ralphjacobs
+    ramonski
     rbanffy
     rbeylerian
     reebalazs
@@ -1227,7 +1228,7 @@ owners = mrsavage
 
 [repo:collective.logbook]
 teams = contributors
-owners = miohtama
+owners = miohtama ramonski
 
 [repo:collective.loremipsum]
 teams = contributors
@@ -1883,6 +1884,10 @@ owners = rpatterson
 [repo:collective.upload]
 teams = contributors
 owners = hvelarde Quimera saibatizoku
+
+[repo:collective.uploadify]
+teams = contributors
+owners = ramonski
 
 [repo:collective.userstats]
 teams = contributors


### PR DESCRIPTION
added ramonski to team:contributors.
added repository repo:collective.uploadify.
added ramonski to the owners of collective.logbook
