### PR TITLE
new repo to move collective.portlet.content from svn

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1401,6 +1401,10 @@ fork = tomgross/collective.portlet.actions
 teams = contributors
 owners = glenfant tomgross
 
+[repo:collective.portlet.content]
+teams = contributors
+owners = khink huubbouma regebro malthe kcleong helmantel sneridagh keul
+
 [repo:collective.portlet.calendar]
 teams = contributors
 owners = ericof hvelarde lepri cleberjsantos


### PR DESCRIPTION
added pypi maintainers as owners
