### PR TITLE
Add `collective.usernamelogger` repository.

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -2049,6 +2049,10 @@ owners = hvelarde Quimera saibatizoku
 teams = contributors
 owners = ramonski
 
+[repo:collective.usernamelogger]
+teams = contributors
+owners = witsch
+
 [repo:collective.userstats]
 teams = contributors
 owners = ericof frapell hvelarde


### PR DESCRIPTION
To be migrated from collective SVN…
