### PR TITLE
Contributor access to migrate repository

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -2290,6 +2290,10 @@ owners = gborelli davidjb
 teams = contributors
 owners = frapell hvelarde Quimera
 
+[repo:collective.z3cform.wizard]
+teams = contributors
+owners = davisagli
+
 [repo:collective.z3cinspector]
 teams = contributors
 owners = jone


### PR DESCRIPTION
I've talked to David on IRC , if `collective.z3cform.wizard` could be migrated to github. Since he does not have time to migrate the repository, but I'd like to commit a fix for it, I'd like to ask for permission to access the collective.
