### PR TITLE
migrate Products.cron4plone to github

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -2937,6 +2937,10 @@ owners = toutpt
 teams = contributors
 owners = takanory
 
+[repo:Products.cron4plone]
+teams = contributors
+owners = huubbouma kcleong khink
+
 [repo:Products.csvreplicata]
 teams = contributors
 owners = kiorky


### PR DESCRIPTION
Want to move https://svn.plone.org/svn/collective/Products.cron4plone/ to github
