### PR TITLE
Added two repositories that should be migrated from collective subversion

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -1410,6 +1410,10 @@ owners = cleder
 teams = contributors
 owners = garbas
 
+[repo:collective.layout.authpersonalbar]
+teams = contributors
+owners = j23d
+
 [repo:collective.lesscss]
 teams = contributors
 owners = sneridagh
@@ -1986,6 +1990,10 @@ owners = marciomazza
 [repo:collective.recipe.rsync]
 teams = contributors
 owners = aclark4life
+
+[repo:collective.recipe.shelloutput]
+teams = contributors
+owners = j23d
 
 [repo:collective.recipe.solrinstance]
 fork = hannosch/collective.recipe.solrinstance


### PR DESCRIPTION
collective.layout.authpersonalbar and collective.recipe.shelloutput
