### PR TITLE
Add jlantz as contributor

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -156,6 +156,7 @@ members =
     jfroche
     jhb
     jianaijun
+    jlantz
     jodok
     joka
     jonascho


### PR DESCRIPTION
I've got a new package, collective.chimpdrill, which integrates Plone with Mailchimp and Mandrill for sending transactional emails using those templates.  I'd love to add it to the collective.
